### PR TITLE
feat(order-service): implement Order, Stage, WorkshopInvitation and request entities

### DIFF
--- a/apps/order-service/src/app/order-workflow/domain/entities/common/assert-is-found.assertion.ts
+++ b/apps/order-service/src/app/order-workflow/domain/entities/common/assert-is-found.assertion.ts
@@ -1,0 +1,25 @@
+import { DomainError} from 'error-handling/error-core';
+import {OrderDomainErrorRegistry} from 'error-handling/registries/order'
+
+export function assertIsFound<event extends { name: string }>(
+  object: unknown,
+  entity: event,
+  ids?: {
+    orderId?: string;
+    commissionerId?: string;
+    workshopId?: string;
+  },
+): asserts object is event {
+  if (!object) {
+    throw new DomainError({
+      errorObject: OrderDomainErrorRegistry.byCode.NOT_FOUND,
+      details: {
+        description: `${entity?.name} entity with orderId: ${ids?.orderId} does not exist`,
+        entity: entity?.name,
+        orderId: ids?.orderId,
+        commissionerId: ids?.commissionerId,
+        workshopId: ids?.workshopId,
+      },
+    });
+  }
+}

--- a/apps/order-service/src/app/order-workflow/domain/entities/order/order.entity.spec.ts
+++ b/apps/order-service/src/app/order-workflow/domain/entities/order/order.entity.spec.ts
@@ -1,0 +1,224 @@
+// Adjust the import to your file location
+
+import { Order } from 'apps/order-service/src/app/order-workflow/domain/entities/order/order.entity';
+import {
+  OrderStates,
+  OrderActions,
+} from 'apps/order-service/src/app/order-workflow/domain/entities/order/order.enum';
+import {
+  PendingWorkshopInvitations,
+  PendingCompletion,
+  MarkedAsCompleted,
+  Completed,
+  Cancelled,
+  CancelDisputeOpened,
+} from 'apps/order-service/src/app/order-workflow/domain/entities/order/order.state';
+
+const T0 = '2025-01-01T00:00:00.000Z';
+
+function makeOrderIn(initial: OrderStates): Order {
+  const o = Object.create(Order.prototype) as Order;
+  o.orderId = '11111111-1111-4111-8111-111111111111';
+  o.commissionerId = '22222222-1111-4111-8111-111111111111';
+  o.createdAt = T0;
+  o.lastUpdatedAt = T0;
+  o.isTerminated = false;
+
+  switch (initial) {
+    case OrderStates.PendingWorkshopInvitations:
+      o.state = new PendingWorkshopInvitations();
+      break;
+    case OrderStates.PendingCompletion:
+      o.state = new PendingCompletion();
+      break;
+    case OrderStates.MarkedAsCompleted:
+      o.state = new MarkedAsCompleted();
+      break;
+    case OrderStates.Completed:
+      o.state = new Completed();
+      break;
+    case OrderStates.Cancelled:
+      o.state = new Cancelled();
+      break;
+    case OrderStates.CancelDisputeOpened:
+      o.state = new CancelDisputeOpened();
+      break;
+  }
+  return o;
+}
+
+describe('Order state machine', () => {
+  describe('[Initial: PendingWorkshopInvitations]', () => {
+    test('legal: TransitionToPendingCompletion -> PendingCompletion; lastUpdatedAt changes', () => {
+      const o = makeOrderIn(OrderStates.PendingWorkshopInvitations);
+      o.transitionToPendingCompletion();
+      expect(o.state).toBeInstanceOf(PendingCompletion);
+      expect(o.lastUpdatedAt).not.toBe(T0); // changed, exact value irrelevant
+      expect(typeof o.lastUpdatedAt).toBe('string');
+      expect(o.isTerminated).toBe(false);
+    });
+
+    test('legal: Cancel -> Cancelled; lastUpdatedAt changes; terminated true', () => {
+      const o = makeOrderIn(OrderStates.PendingWorkshopInvitations);
+      o.cancelOrder();
+      expect(o.state).toBeInstanceOf(Cancelled);
+      expect(o.lastUpdatedAt).not.toBe(T0);
+      expect(o.isTerminated).toBe(true);
+    });
+
+    test('illegal: Complete throws; lastUpdatedAt unchanged; not terminated', () => {
+      const o = makeOrderIn(OrderStates.PendingWorkshopInvitations);
+      expect(() => o.complete()).toThrow();
+      expect(o.lastUpdatedAt).toBe(T0);
+      expect(o.isTerminated).toBe(false);
+    });
+
+    test('illegal (handler): MarkAsComplete from PendingWorkshopInvitations is illegal', () => {
+      const s = new PendingWorkshopInvitations();
+      const out = s.handle(OrderActions.MarkAsComplete);
+      expect(out.type).toBe('illegal');
+    });
+  });
+
+  describe('[Initial: PendingCompletion]', () => {
+    test('legal (handler): MarkAsComplete -> MarkedAsCompleted', () => {
+      const s = new PendingCompletion();
+      const out = s.handle(OrderActions.MarkAsComplete);
+      expect(out.type).toBe('legal');
+      expect(out.nextState).toBe(MarkedAsCompleted);
+    });
+
+    test('legal (entity): Cancel -> CancelDisputeOpened; lastUpdatedAt changes; terminated true', () => {
+      const o = makeOrderIn(OrderStates.PendingCompletion);
+      o.cancelOrder();
+      expect(o.state).toBeInstanceOf(CancelDisputeOpened);
+      expect(o.lastUpdatedAt).not.toBe(T0);
+      expect(o.isTerminated).toBe(true);
+    });
+
+    test('illegal: TransitionToPendingCompletion throws; lastUpdatedAt unchanged', () => {
+      const o = makeOrderIn(OrderStates.PendingCompletion);
+      expect(() => o.transitionToPendingCompletion()).toThrow();
+      expect(o.lastUpdatedAt).toBe(T0);
+    });
+
+    test('illegal: Complete throws; lastUpdatedAt unchanged; not terminated', () => {
+      const o = makeOrderIn(OrderStates.PendingCompletion);
+      expect(() => o.complete()).toThrow();
+      expect(o.lastUpdatedAt).toBe(T0);
+      expect(o.isTerminated).toBe(false);
+    });
+  });
+
+  describe('[Initial: MarkedAsCompleted]', () => {
+    test('legal: Complete -> Completed; lastUpdatedAt changes; terminated true', () => {
+      const o = makeOrderIn(OrderStates.MarkedAsCompleted);
+      o.complete();
+      expect(o.state).toBeInstanceOf(Completed);
+      expect(o.lastUpdatedAt).not.toBe(T0);
+      expect(o.isTerminated).toBe(true);
+    });
+
+    test('legal: Cancel -> CancelDisputeOpened; lastUpdatedAt changes; terminated true', () => {
+      const o = makeOrderIn(OrderStates.MarkedAsCompleted);
+      o.cancelOrder();
+      expect(o.state).toBeInstanceOf(CancelDisputeOpened);
+      expect(o.lastUpdatedAt).not.toBe(T0);
+      expect(o.isTerminated).toBe(true);
+    });
+
+    test('illegal: TransitionToPendingCompletion throws; lastUpdatedAt unchanged; not terminated', () => {
+      const o = makeOrderIn(OrderStates.MarkedAsCompleted);
+      expect(() => o.transitionToPendingCompletion()).toThrow();
+      expect(o.lastUpdatedAt).toBe(T0);
+      expect(o.isTerminated).toBe(false);
+    });
+  });
+
+  describe('[Initial: Completed]', () => {
+    test('illegal: TransitionToPendingCompletion throws; lastUpdatedAt unchanged', () => {
+      const o = makeOrderIn(OrderStates.Completed);
+      expect(() => o.transitionToPendingCompletion()).toThrow();
+      expect(o.lastUpdatedAt).toBe(T0);
+    });
+
+    test('illegal: Complete throws; lastUpdatedAt unchanged; not terminated', () => {
+      const o = makeOrderIn(OrderStates.Completed);
+      expect(() => o.complete()).toThrow();
+      expect(o.lastUpdatedAt).toBe(T0);
+      expect(o.isTerminated).toBe(false);
+    });
+
+    test('illegal: Cancel throws (terminal); lastUpdatedAt unchanged', () => {
+      const o = makeOrderIn(OrderStates.Completed);
+      expect(() => o.cancelOrder()).toThrow();
+      expect(o.lastUpdatedAt).toBe(T0);
+      expect(o.isTerminated).toBe(false);
+    });
+  });
+
+  describe('[Initial: Cancelled]', () => {
+    test('illegal: any action throws; lastUpdatedAt unchanged', () => {
+      const o = makeOrderIn(OrderStates.Cancelled);
+      expect(() => o.transitionToPendingCompletion()).toThrow();
+      expect(() => o.complete()).toThrow();
+      expect(() => o.cancelOrder()).toThrow();
+      expect(o.lastUpdatedAt).toBe(T0);
+    });
+  });
+
+  describe('[Initial: CancelDisputeOpened]', () => {
+    test('illegal: any action throws; lastUpdatedAt unchanged', () => {
+      const o = makeOrderIn(OrderStates.CancelDisputeOpened);
+      expect(() => o.transitionToPendingCompletion()).toThrow();
+      expect(() => o.complete()).toThrow();
+      expect(() => o.cancelOrder()).toThrow();
+      expect(o.lastUpdatedAt).toBe(T0);
+    });
+  });
+
+  // Sanity: handlers encode the transition table; no time checks
+  describe('[Handler sanity]', () => {
+    test('PendingWorkshopInvitations allows only TransitionToPendingCompletion and Cancel', () => {
+      const s = new PendingWorkshopInvitations();
+      expect(s.handle(OrderActions.TransitionToPendingCompletion).type).toBe(
+        'legal',
+      );
+      expect(s.handle(OrderActions.Cancel).type).toBe('legal');
+      expect(s.handle(OrderActions.MarkAsComplete).type).toBe('illegal');
+      expect(s.handle(OrderActions.Complete).type).toBe('illegal');
+    });
+
+    test('PendingCompletion allows MarkAsComplete and Cancel', () => {
+      const s = new PendingCompletion();
+      expect(s.handle(OrderActions.MarkAsComplete).type).toBe('legal');
+      expect(s.handle(OrderActions.Cancel).type).toBe('legal');
+      expect(s.handle(OrderActions.TransitionToPendingCompletion).type).toBe(
+        'illegal',
+      );
+      expect(s.handle(OrderActions.Complete).type).toBe('illegal');
+    });
+
+    test('MarkedAsCompleted allows Complete and Cancel', () => {
+      const s = new MarkedAsCompleted();
+      expect(s.handle(OrderActions.Complete).type).toBe('legal');
+      expect(s.handle(OrderActions.Cancel).type).toBe('legal');
+      expect(s.handle(OrderActions.MarkAsComplete).type).toBe('illegal');
+      expect(s.handle(OrderActions.TransitionToPendingCompletion).type).toBe(
+        'illegal',
+      );
+    });
+
+    test('Terminal states have no legal handlers', () => {
+      for (const S of [Completed, Cancelled, CancelDisputeOpened] as const) {
+        const s = new S();
+        expect(s.handle(OrderActions.TransitionToPendingCompletion).type).toBe(
+          'illegal',
+        );
+        expect(s.handle(OrderActions.MarkAsComplete).type).toBe('illegal');
+        expect(s.handle(OrderActions.Complete).type).toBe('illegal');
+        expect(s.handle(OrderActions.Cancel).type).toBe('illegal');
+      }
+    });
+  });
+});

--- a/apps/order-service/src/app/order-workflow/domain/entities/order/order.entity.ts
+++ b/apps/order-service/src/app/order-workflow/domain/entities/order/order.entity.ts
@@ -1,0 +1,210 @@
+import {
+  OrderActions,
+  OrderStates,
+} from 'apps/order-service/src/app/order-workflow/domain/entities/order/order.enum';
+import {
+  PendingWorkshopInvitations,
+  Cancelled,
+  CancelDisputeOpened,
+} from 'apps/order-service/src/app/order-workflow/domain/entities/order/order.state';
+import {
+  Outcome,
+  LegalOutcome,
+  StateUnion,
+  StateById,
+} from 'apps/order-service/src/app/order-workflow/domain/entities/order/order.type';
+import { RequestEntity } from 'apps/order-service/src/app/order-workflow/domain/entities/request/request.entity';
+import {
+  IsUUID,
+  IsString,
+  Length,
+  IsISO8601,
+  IsInt,
+  IsBoolean,
+} from 'class-validator';
+import {
+  EntityTechnicalsInterface,
+  IsoDateTransformer,
+} from 'persistence';
+import {
+  Index,
+  Entity,
+  PrimaryColumn,
+  Column,
+  UpdateDateColumn,
+  CreateDateColumn,
+  VersionColumn,
+  OneToOne,
+} from 'typeorm';
+import { assertValid, isoNow } from 'shared-kernel';
+import { DomainError } from 'error-handling/error-core';
+import { OrderDomainErrorRegistry } from 'error-handling/registries/order';
+
+
+/**
+ * Primary aggregate root/state-machine owning the Order workflow.
+ */
+@Index('ix_order_commissioner', ['commissionerId'])
+@Entity({ name: 'order' })
+export class Order implements EntityTechnicalsInterface {
+  @IsUUID()
+  @PrimaryColumn('uuid', { name: 'order_id' })
+  orderId!: string;
+
+  @IsString()
+  @Length(1, 64)
+  @Index()
+  @Column('varchar', { name: 'state', length: 64 })
+  state!: any;
+
+  @IsUUID()
+  @Column('uuid', { name: 'commissioner_id' })
+  commissionerId!: string;
+
+  //@IsISO8601()
+  @UpdateDateColumn({
+    name: 'last_updated_at',
+    type: 'timestamptz',
+    transformer: IsoDateTransformer,
+  })
+  lastUpdatedAt!: string;
+
+  //@IsISO8601()
+  @CreateDateColumn({
+    name: 'created_at',
+    type: 'timestamptz',
+    transformer: IsoDateTransformer,
+  })
+  createdAt!: string;
+
+  @IsInt()
+  @VersionColumn({ name: 'version', type: 'int' })
+  version!: number;
+
+  @IsBoolean()
+  @Column('boolean', { name: 'is_terminated', default: false })
+  isTerminated!: boolean;
+
+  @OneToOne(() => RequestEntity, (r) => r.order, { eager: false })
+  request!: RequestEntity;
+
+  constructor(init: { commissionerId: string }) {
+    // typeorm fix
+    if (!init) return;
+
+    this.orderId = crypto.randomUUID();
+    this.state = new PendingWorkshopInvitations();
+    this.commissionerId = init.commissionerId;
+
+    this.isTerminated = false;
+    assertValid(this, OrderDomainErrorRegistry);
+  }
+
+  transitionToPendingCompletion() {
+    const action = OrderActions.TransitionToPendingCompletion;
+    const assumed = OrderStates.PendingWorkshopInvitations;
+
+    this.assertCurrentStateIs(assumed, this.state, action);
+
+    const outcome: Outcome<typeof assumed, typeof action> = this.state.handle(
+      action,
+    ) satisfies LegalOutcome<typeof assumed, typeof action>;
+
+    this.state = new outcome.nextState();
+
+    this.lastUpdatedAt = isoNow();
+  }
+
+  complete() {
+    const action = OrderActions.Complete;
+    const assumed = OrderStates.MarkedAsCompleted;
+
+    this.assertCurrentStateIs(assumed, this.state, action);
+
+    const outcome: Outcome<typeof assumed, typeof action> = this.state.handle(
+      action,
+    ) satisfies LegalOutcome<typeof assumed, typeof action>;
+
+    this.state = new outcome.nextState();
+
+    this.lastUpdatedAt = isoNow();
+    this.isTerminated = true;
+  }
+
+  cancelOrder() {
+    const action = OrderActions.Cancel;
+
+    // Only these non-terminal states can accept Cancel.
+    const allowed = [
+      OrderStates.PendingWorkshopInvitations,
+      OrderStates.PendingCompletion,
+      OrderStates.MarkedAsCompleted,
+    ] as const;
+
+    this.assertCurrentStateIsOneOf(allowed, this.state, action);
+
+    switch (this.state.stateName) {
+      case OrderStates.PendingWorkshopInvitations: {
+        const outcome: Outcome<
+          OrderStates.PendingWorkshopInvitations,
+          OrderActions.Cancel
+        > = this.state.handle(action);
+        const nextState: Cancelled = new outcome.nextState();
+        this.state = nextState;
+        break;
+      }
+      case OrderStates.PendingCompletion:
+      case OrderStates.MarkedAsCompleted: {
+        const outcome: Outcome<
+          OrderStates.PendingCompletion | OrderStates.MarkedAsCompleted,
+          OrderActions.Cancel
+        > = this.state.handle(action);
+        const nextState: CancelDisputeOpened = new outcome.nextState();
+        this.state = nextState;
+        break;
+      }
+    }
+
+    this.lastUpdatedAt = isoNow();
+    this.isTerminated = true;
+  }
+  /**
+   * Asserts that the current state equals `assumed`. Narrows `state` on success.
+   */
+  private assertCurrentStateIs<S extends OrderStates>(
+    assumed: S,
+    state: StateUnion,
+    action: OrderActions,
+  ): asserts state is StateById[S] {
+    if (state.stateName !== assumed) {
+      throw new DomainError({
+        errorObject: OrderDomainErrorRegistry.byCode.ILLEGAL_TRANSITION,
+        details: {
+          description: `Attempt to transition from ${state.stateName} using ${action} - illegal`,
+          currentState: state.stateName,
+          action,
+        },
+      });
+    }
+  }
+
+  /**
+   * Asserts that the current state is one of `allowed`. Narrows `state` to the union.
+   */
+  private assertCurrentStateIsOneOf<S extends OrderStates>(
+    allowed: readonly S[],
+    state: StateUnion,
+    action: OrderActions,
+  ): asserts state is StateById[S] {
+    if (!allowed.includes(state.stateName as S)) {
+      throw new DomainError({
+        errorObject: OrderDomainErrorRegistry.byCode.ILLEGAL_TRANSITION,
+        details: {
+          description: `Attempt to transition from ${state.stateName} using ${action} - illegal`,
+          currentState: state.stateName,
+          action,
+        },
+      });
+    }
+  }
+}

--- a/apps/order-service/src/app/order-workflow/domain/entities/order/order.enum.ts
+++ b/apps/order-service/src/app/order-workflow/domain/entities/order/order.enum.ts
@@ -1,0 +1,14 @@
+export enum OrderStates {
+  PendingWorkshopInvitations = 'PendingWorkshopInvitations',
+  PendingCompletion = 'PendingCompletion',
+  MarkedAsCompleted = 'MarkedAsCompleted',
+  Completed = 'Completed',
+  Cancelled = 'Cancelled',
+  CancelDisputeOpened = 'CancelDisputeOpened',
+}
+export enum OrderActions {
+  TransitionToPendingCompletion,
+  Cancel,
+  MarkAsComplete,
+  Complete,
+}

--- a/apps/order-service/src/app/order-workflow/domain/entities/order/order.state.ts
+++ b/apps/order-service/src/app/order-workflow/domain/entities/order/order.state.ts
@@ -1,0 +1,70 @@
+import {
+  OrderStates,
+  OrderActions,
+} from 'apps/order-service/src/app/order-workflow/domain/entities/order/order.enum';
+import {
+  BaseState,
+  Handlers,
+} from 'apps/order-service/src/app/order-workflow/domain/entities/order/order.type';
+
+export class PendingWorkshopInvitations extends BaseState<OrderStates.PendingWorkshopInvitations> {
+  readonly stateName = OrderStates.PendingWorkshopInvitations as const;
+
+  handlers = {
+    [OrderActions.TransitionToPendingCompletion]: {
+      nextState: PendingCompletion,
+      type: 'legal',
+    },
+    [OrderActions.Cancel]: { nextState: Cancelled, type: 'legal' },
+  } satisfies Handlers<OrderStates.PendingWorkshopInvitations>;
+}
+
+export class PendingCompletion extends BaseState<OrderStates.PendingCompletion> {
+  readonly stateName = OrderStates.PendingCompletion as const;
+
+  handlers = {
+    [OrderActions.MarkAsComplete]: {
+      nextState: MarkedAsCompleted,
+      type: 'legal',
+    },
+    [OrderActions.Cancel]: { nextState: CancelDisputeOpened, type: 'legal' },
+  } satisfies Handlers<OrderStates.PendingCompletion>;
+}
+
+export class MarkedAsCompleted extends BaseState<OrderStates.MarkedAsCompleted> {
+  readonly stateName = OrderStates.MarkedAsCompleted as const;
+
+  handlers = {
+    [OrderActions.Complete]: { nextState: Completed, type: 'legal' },
+    [OrderActions.Cancel]: { nextState: CancelDisputeOpened, type: 'legal' },
+  } satisfies Handlers<OrderStates.MarkedAsCompleted>;
+}
+
+export class Completed extends BaseState<OrderStates.Completed> {
+  readonly stateName = OrderStates.Completed as const;
+
+  handlers = {} satisfies Handlers<OrderStates.Completed>;
+}
+
+export class Cancelled extends BaseState<OrderStates.Cancelled> {
+  readonly stateName = OrderStates.Cancelled as const;
+
+  handlers = {} satisfies Handlers<OrderStates.Cancelled>;
+}
+
+export class CancelDisputeOpened extends BaseState<OrderStates.CancelDisputeOpened> {
+  readonly stateName = OrderStates.CancelDisputeOpened as const;
+
+  handlers = {} satisfies Handlers<OrderStates.CancelDisputeOpened>;
+}
+
+
+
+export const StateRegistry = {
+  [OrderStates.PendingWorkshopInvitations]: PendingWorkshopInvitations,
+  [OrderStates.PendingCompletion]: PendingCompletion,
+  [OrderStates.MarkedAsCompleted]: MarkedAsCompleted,
+  [OrderStates.Completed]: Completed,
+  [OrderStates.Cancelled]: Cancelled,
+  [OrderStates.CancelDisputeOpened]: CancelDisputeOpened,
+} as const;

--- a/apps/order-service/src/app/order-workflow/domain/entities/order/order.transitions.ts
+++ b/apps/order-service/src/app/order-workflow/domain/entities/order/order.transitions.ts
@@ -1,0 +1,28 @@
+import {
+  OrderStates,
+  OrderActions,
+} from 'apps/order-service/src/app/order-workflow/domain/entities/order/order.enum';
+
+/**
+ * The absolute source of truth for state transitions.
+ */
+export const OrderTransitions = {
+  [OrderStates.PendingWorkshopInvitations]: {
+    [OrderActions.TransitionToPendingCompletion]: OrderStates.PendingCompletion,
+    [OrderActions.Cancel]: OrderStates.Cancelled,
+  },
+  [OrderStates.PendingCompletion]: {
+    [OrderActions.MarkAsComplete]: OrderStates.MarkedAsCompleted,
+    [OrderActions.Cancel]: OrderStates.CancelDisputeOpened,
+  },
+  [OrderStates.MarkedAsCompleted]: {
+    [OrderActions.Complete]: OrderStates.Completed,
+    [OrderActions.Cancel]: OrderStates.CancelDisputeOpened,
+  },
+  [OrderStates.Completed]: {},
+  [OrderStates.Cancelled]: {},
+  [OrderStates.CancelDisputeOpened]: {},
+} as const satisfies Record<
+  OrderStates,
+  Partial<Record<OrderActions, OrderStates>>
+>;

--- a/apps/order-service/src/app/order-workflow/domain/entities/order/order.type.ts
+++ b/apps/order-service/src/app/order-workflow/domain/entities/order/order.type.ts
@@ -1,0 +1,103 @@
+import {
+  OrderStates,
+  OrderActions,
+} from 'apps/order-service/src/app/order-workflow/domain/entities/order/order.enum';
+import { StateRegistry } from 'apps/order-service/src/app/order-workflow/domain/entities/order/order.state';
+import { OrderTransitions } from 'apps/order-service/src/app/order-workflow/domain/entities/order/order.transitions';
+
+
+
+
+
+//Helper-types
+type ConstructorType<T> = new (...args: any[]) => T;
+
+export type CtorById = {
+  [K in OrderStates]: (typeof StateRegistry)[K];
+};
+
+export type StateById = {
+  [K in OrderStates]: InstanceType<(typeof StateRegistry)[K]>;
+};
+
+export type StateUnion = StateById[OrderStates];
+
+
+//Important business-logic types
+export type Handlers<S extends OrderStates> = {
+  [A in NextActions<S>]: LegalOutcome<S, A>;
+};
+/**
+ * Automatically computes legality of the transition on compile-time.
+ */
+export type Outcome<S extends OrderStates, A extends OrderActions> =
+  A extends NextActions<S> ? LegalOutcome<S, A> : IllegalOutcome;
+
+
+type TransitionsOf<S extends OrderStates> = (typeof OrderTransitions)[S];
+
+
+export type NextActions<S extends OrderStates> = Extract< //Extraction removes undefined - compiler fix
+  keyof TransitionsOf<S>,
+  OrderActions
+>;
+
+type NextStateFor<S extends OrderStates, A extends NextActions<S>> = Extract<
+  TransitionsOf<S>[A],
+  OrderStates
+>;
+
+export interface AbstractOutcome {
+  type: string;
+  nextState: any;
+}
+
+export class LegalOutcomeS<s extends OrderStates, a extends NextActions<s>>
+  implements AbstractOutcome
+{
+  type: 'legal';
+  nextState: ConstructorType<BaseState<NextStateFor<s, a>>>;
+}
+export type LegalOutcome<S extends OrderStates, A extends NextActions<S>> = {
+  type: 'legal';
+  nextState: CtorById[NextStateFor<S, A>];
+};
+
+export class IllegalOutcome implements AbstractOutcome {
+  type: 'illegal';
+  nextState: undefined;
+}
+
+
+
+
+
+export abstract class BaseState<s extends OrderStates> {
+  readonly stateName: s;
+  abstract readonly handlers: Handlers<s>;
+
+  /**
+   * The return type is automatically computed to be either
+   * LegalOutcome or IllegalOutcome by the compiler 
+   * */
+  handle<a extends OrderActions>(action: a): Outcome<s, a> {
+    function isKeyOf<T extends object, K extends PropertyKey>(
+      obj: T,
+      key: K,
+    ): key is Extract<keyof T, K> {
+      return key in obj;
+    }
+
+    let outcome:
+      | LegalOutcome<s, Extract<keyof Handlers<s>, a>>
+      | IllegalOutcome;
+    if (isKeyOf(this.handlers, action)) {
+      outcome = this.handlers[action];
+    } else {
+      outcome = { type: 'illegal', nextState: undefined };
+    }
+    return outcome as Outcome<s, a>;
+  }
+}
+
+

--- a/apps/order-service/src/app/order-workflow/domain/entities/request/request.entity.ts
+++ b/apps/order-service/src/app/order-workflow/domain/entities/request/request.entity.ts
@@ -1,0 +1,155 @@
+import {
+  Entity,
+  PrimaryColumn,
+  Column,
+  OneToOne,
+  JoinColumn,
+  Check,
+  Index,
+  UpdateDateColumn,
+  OneToMany,
+  VersionColumn,
+  CreateDateColumn,
+} from 'typeorm';
+import {
+  IsUUID,
+  IsString,
+  IsNotEmpty,
+  Length,
+  IsISO8601,
+  IsInt,
+} from 'class-validator';
+
+import {
+  EntityTechnicalsInterface,
+  IsoDateTransformer,
+} from 'persistence';
+import { Order } from 'apps/order-service/src/app/order-workflow/domain/entities/order/order.entity';
+import { WorkshopInvitation } from 'apps/order-service/src/app/order-workflow/domain/entities/workshop-invitation/workshop-invitation.entity';
+import { assertValid } from 'shared-kernel';
+import { OrderDomainErrorRegistry } from 'error-handling/registries/order';
+
+/**
+ * A part of the Order containing lots of static data, such as description.
+ * Contains ".edit" logic independent of the workflow state, hence separated.
+ */
+@Check('chk_request_title_nonempty', `char_length(title) >= 1`)
+@Entity({ name: 'request' })
+export class RequestEntity implements EntityTechnicalsInterface {
+  @IsUUID()
+  @PrimaryColumn('uuid', { name: 'order_id' })
+  orderId!: string;
+
+  @OneToOne(() => Order, (o) => o.request, {
+    onDelete: 'CASCADE',
+    eager: false,
+  })
+  @JoinColumn({ name: 'order_id', referencedColumnName: 'orderId' })
+  order!: Order;
+
+  @IsString()
+  @IsNotEmpty()
+  @Length(1, 200)
+  @Column('varchar', { name: 'title', length: 200 })
+  title!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @Column('text', { name: 'description' })
+  description!: string;
+
+  //@IsISO8601()
+  @Column({
+    name: 'deadline',
+    type: 'timestamptz',
+    transformer: IsoDateTransformer,
+  })
+  deadline!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @Column('varchar', { name: 'budget', length: 64 })
+  budget!: string;
+
+  //@IsISO8601()
+  @UpdateDateColumn({
+    name: 'last_updated_at',
+    type: 'timestamptz',
+    transformer: IsoDateTransformer,
+  })
+  lastUpdatedAt!: string;
+
+  //@IsISO8601()
+  @CreateDateColumn({
+    name: 'created_at',
+    type: 'timestamptz',
+    transformer: IsoDateTransformer,
+  })
+  createdAt!: string;
+
+  @IsInt()
+  @VersionColumn({ name: 'version', type: 'int' })
+  version!: number;
+
+  @OneToMany(() => WorkshopInvitation, (o) => o.request, { eager: false })
+  workshopInvitations!: WorkshopInvitation[];
+
+  constructor(init: {
+    orderId: string;
+    title: string;
+    description: string;
+    deadline: string;
+    budget: string;
+  }) {
+    // typeorm fix
+    if (!init) return;
+
+    this.orderId = init.orderId;
+    this.title = init.title;
+    this.description = init.description;
+    this.deadline = init.deadline;
+    this.budget = init.budget;
+
+    assertValid(this, OrderDomainErrorRegistry);
+  }
+
+  editBudget(newbBudget: string): void {
+    const oldBudget = this.budget;
+
+    this.budget = newbBudget;
+
+    try {
+      assertValid(this, OrderDomainErrorRegistry);
+    } catch (Error) {
+      this.budget = oldBudget;
+
+      throw Error;
+    }
+  }
+
+  editDescription(newDescription: string): void {
+    const olddescription = this.description;
+    this.description = newDescription;
+
+    try {
+      assertValid(this, OrderDomainErrorRegistry);
+    } catch (Error) {
+      this.description = olddescription;
+
+      throw Error;
+    }
+  }
+
+  editDeadline(newDeadline: string): void {
+    const oldDeadline = this.deadline;
+    this.deadline = newDeadline;
+
+    try {
+      assertValid(this, OrderDomainErrorRegistry);
+    } catch (Error) {
+      this.deadline = oldDeadline;
+
+      throw Error;
+    }
+  }
+}

--- a/apps/order-service/src/app/order-workflow/domain/entities/stage/stage-defaults.factory.ts
+++ b/apps/order-service/src/app/order-workflow/domain/entities/stage/stage-defaults.factory.ts
@@ -1,0 +1,24 @@
+import { constructStageData } from 'apps/order-service/src/app/order-workflow/domain/entities/stage/stage.entity';
+
+/**
+ * Is responsible for producing non-user-defined stage data.
+ * May be extended to contain complex creation/fallback logic in the future.
+ */
+export const stagesTemplateFactory = {
+  produceDefault: (
+    orderId: string,
+    workshopId: string,
+    needsConfirmation: boolean = false,
+  ): constructStageData => {
+    return {
+      orderId: orderId,
+      workshopId: workshopId,
+      stageName: 'Order',
+      approximateLength: 'unspecified',
+      needsConfirmation: needsConfirmation,
+      description: 'Your order',
+      stageOrder: 0,
+    };
+    
+  },
+};

--- a/apps/order-service/src/app/order-workflow/domain/entities/stage/stage-status.enum.ts
+++ b/apps/order-service/src/app/order-workflow/domain/entities/stage/stage-status.enum.ts
@@ -1,0 +1,7 @@
+
+
+export enum StageStatus {
+  Pending = 'pending',
+  AwaitingConfirmation = 'awaitingConfirmation',
+  Completed = 'completed'
+}

--- a/apps/order-service/src/app/order-workflow/domain/entities/stage/stage.entity.spec.ts
+++ b/apps/order-service/src/app/order-workflow/domain/entities/stage/stage.entity.spec.ts
@@ -1,0 +1,288 @@
+// apps/order-service/modules/order-workflow/domain/__tests__/stages-aggregate.spec.ts
+import 'reflect-metadata';
+
+// Adjust these paths to your project layout:
+import { StagesAggregate, Stage } from './stage.entity';
+import { isoNow } from 'shared-kernel';
+import { StageStatus } from 'apps/order-service/src/app/order-workflow/domain/entities/stage/stage-status.enum';
+
+describe('StagesAggregate', () => {
+  // ---------------- helpers ----------------
+  const uuid = (n = 1) =>
+    `${String(n).padStart(8, '0')}-1111-4111-8111-11111111111${n}`;
+
+  const makeStageData = (over: Partial<Stage> = {}) => ({
+    orderId: over.orderId ?? uuid(1),
+    workshopId: over.workshopId ?? uuid(2),
+    stageName:
+      over.stageName ?? `stage-${Math.random().toString(36).slice(2, 7)}`,
+    approximateLength: over.approximateLength ?? '2d',
+    needsConfirmation: over.needsConfirmation ?? false,
+    description: over.description ?? 'desc',
+    stageOrder: over.stageOrder ?? 0, // 0-based
+    version: over.version ?? 1,
+    createdAt: over.createdAt ?? isoNow(),
+    lastEditedAt: over.lastUpdatedAt ?? isoNow(),
+  });
+
+  describe('constructor & invariants', () => {
+    it('normalizes plain objects to Stage instances and preserves Stage instances', () => {
+      const s0 = new Stage(
+        makeStageData({ stageName: 'design', stageOrder: 0 }),
+      );
+      const d1 = makeStageData({ stageName: 'engrave', stageOrder: 1 });
+
+      const agg = new StagesAggregate([s0, d1]);
+
+      expect(agg.amountOfStages).toBe(2);
+      expect(agg.stages.length).toBe(2);
+      expect(agg.stages[0]).toBeInstanceOf(Stage);
+      expect(agg.stages[1]).toBeInstanceOf(Stage);
+      expect(agg.currentStage).toBe(0); // first pending
+    });
+
+    it('throws on duplicate stage_order', () => {
+      const a = makeStageData({ stageName: 'A', stageOrder: 0 });
+      const b = makeStageData({ stageName: 'B', stageOrder: 0 }); // dup order
+      expect(() => new StagesAggregate([a, b])).toThrow();
+    });
+
+    it('throws on hole in orders (contiguity 0..N-1 enforced)', () => {
+      const s0 = makeStageData({ stageName: 'A', stageOrder: 0 });
+      const s2 = makeStageData({ stageName: 'C', stageOrder: 2 }); // missing 1
+      expect(() => new StagesAggregate([s0, s2])).toThrow();
+    });
+
+    it('throws on duplicate stage_name', () => {
+      const s0 = makeStageData({ stageName: 'same', stageOrder: 0 });
+      const s1 = makeStageData({ stageName: 'same', stageOrder: 1 });
+      expect(() => new StagesAggregate([s0, s1])).toThrow();
+    });
+  });
+
+  describe('transitions (acceptCompletionMarked/complete)', () => {
+    it('transitions to the next state correctly', () => {
+      const s0 = new Stage(
+        makeStageData({
+          stageName: 'A',
+          stageOrder: 0,
+          needsConfirmation: true,
+        }),
+      );
+      const s1 = new Stage(makeStageData({ stageName: 'B', stageOrder: 1 }));
+      const s2 = new Stage(makeStageData({ stageName: 'C', stageOrder: 2 }));
+
+      const agg = new StagesAggregate([s0, s1, s2]);
+
+      agg.acceptCompletionMarked({ stageName: s0.stageName });
+      expect(agg.stages[s0.stageOrder].status).toBe(
+        StageStatus.AwaitingConfirmation,
+      );
+
+      agg.confirmStage({ stageName: s0.stageName });
+      expect(agg.stages[s0.stageOrder].status).toBe(StageStatus.Completed);
+
+      agg.acceptCompletionMarked({ stageName: s1.stageName });
+      expect(agg.stages[s1.stageOrder].status).toBe(StageStatus.Completed);
+    });
+
+    it('correctly detects if the last completion finished all the stages', () => {
+      const s0 = new Stage(
+        makeStageData({
+          stageName: 'A',
+          stageOrder: 0,
+          needsConfirmation: true,
+        }),
+      );
+      const s1 = new Stage(makeStageData({ stageName: 'B', stageOrder: 1 }));
+      const s2 = new Stage(makeStageData({ stageName: 'C', stageOrder: 2 }));
+
+      s0.status = StageStatus.Completed;
+
+      const agg = new StagesAggregate([s0, s1, s2]);
+      const result1 = agg.acceptCompletionMarked({ stageName: s1.stageName });
+      const result2 = agg.acceptCompletionMarked({ stageName: s2.stageName });
+
+      expect(result1.allCompleted).toBe(false);
+      expect(result2.allCompleted).toBe(true);
+    });
+
+    it('throws on incorrect transitions', () => {
+      const s0 = new Stage(
+        makeStageData({
+          stageName: 'A',
+          stageOrder: 0,
+          needsConfirmation: true,
+        }),
+      );
+      const s1 = new Stage(makeStageData({ stageName: 'B', stageOrder: 1 }));
+      const s2 = new Stage(makeStageData({ stageName: 'C', stageOrder: 2 }));
+
+      s0.status = StageStatus.Completed;
+      const agg = new StagesAggregate([s0, s1, s2]);
+
+      expect(() =>
+        agg.acceptCompletionMarked({ stageName: s0.stageName }),
+      ).toThrow();
+      expect(() =>
+        agg.acceptCompletionMarked({ stageName: s2.stageName }),
+      ).toThrow();
+
+      expect(() => agg.confirmStage({ stageName: s0.stageName })).toThrow();
+      expect(() => agg.confirmStage({ stageName: s1.stageName })).toThrow();
+    });
+  });
+
+  describe('currentStage pointer logic', () => {
+    it('marks "currentStage" as "amountOfStages" if all of stages already completed', () => {
+      const s0 = new Stage(
+        makeStageData({
+          stageName: 'A',
+          stageOrder: 0,
+          needsConfirmation: true,
+        }),
+      );
+      const s1 = new Stage(makeStageData({ stageName: 'B', stageOrder: 1 }));
+      const s2 = new Stage(makeStageData({ stageName: 'C', stageOrder: 2 }));
+      // If all completed, sentinel = amountOfStages
+      s0.status = StageStatus.Completed;
+      s1.status = StageStatus.Completed;
+      s2.status = StageStatus.Completed;
+
+      const agg3 = new StagesAggregate([s0, s1, s2]);
+      expect(agg3.currentStage).toBe(3); //separate unit test to ensure amountOfStages = 3
+    });
+
+    it('marks "currentStage" as "amountOfStages" if the last stage got completed', () => {
+      const s0 = new Stage(
+        makeStageData({
+          stageName: 'A',
+          stageOrder: 0,
+          needsConfirmation: true,
+        }),
+      );
+      const s1 = new Stage(makeStageData({ stageName: 'B', stageOrder: 1 }));
+      const s2 = new Stage(makeStageData({ stageName: 'C', stageOrder: 2 }));
+      // If all completed, sentinel = amountOfStages
+      s0.status = StageStatus.Completed;
+      s1.status = StageStatus.Completed;
+      s2.status = StageStatus.Pending;
+
+      const agg4 = new StagesAggregate([s0, s1, s2]);
+
+      agg4.acceptCompletionMarked({ stageName: s2.stageName });
+      expect(agg4.currentStage).toBe(3);
+    });
+
+    it('does not advance past a stage that is awaiting confirmation', () => {
+      const s0 = new Stage(
+        makeStageData({
+          stageName: 'A',
+          stageOrder: 0,
+          needsConfirmation: true,
+        }),
+      );
+      const s1 = new Stage(makeStageData({ stageName: 'B', stageOrder: 1 }));
+      const s2 = new Stage(makeStageData({ stageName: 'C', stageOrder: 2 }));
+
+      s0.status = StageStatus.Completed;
+      s1.status = StageStatus.Completed;
+      s2.status = StageStatus.AwaitingConfirmation;
+
+      const agg2 = new StagesAggregate([s0, s1, s2]);
+      expect(agg2.currentStage).toBe(2);
+    });
+
+    it('increments stage if transitions to completed', () => {
+      const s0 = new Stage(
+        makeStageData({
+          stageName: 'A',
+          stageOrder: 0,
+          needsConfirmation: true,
+        }),
+      );
+      const s1 = new Stage(makeStageData({ stageName: 'B', stageOrder: 1 }));
+      const s2 = new Stage(makeStageData({ stageName: 'C', stageOrder: 2 }));
+      s0.status = StageStatus.AwaitingConfirmation;
+      s1.status = StageStatus.Pending;
+      s2.status = StageStatus.Pending;
+
+      const agg = new StagesAggregate([s0, s1, s2]);
+      agg.confirmStage({ stageName: s0.stageName });
+      expect(agg.currentStage).toBe(1);
+
+      agg.acceptCompletionMarked({ stageName: s1.stageName });
+      expect(agg.currentStage).toBe(2);
+    });
+
+    it('does not increment the stage if transitions to "awaiting comfirmation', () => {
+      const s0 = new Stage(
+        makeStageData({
+          stageName: 'A',
+          stageOrder: 0,
+          needsConfirmation: true,
+        }),
+      );
+      const s1 = new Stage(makeStageData({ stageName: 'B', stageOrder: 1 }));
+      const s2 = new Stage(makeStageData({ stageName: 'C', stageOrder: 2 }));
+      s0.status = StageStatus.Pending;
+      s1.status = StageStatus.Pending;
+      s2.status = StageStatus.Pending;
+
+      const agg = new StagesAggregate([s0, s1, s2]);
+
+      agg.acceptCompletionMarked({ stageName: s0.stageName });
+      expect(agg.currentStage).toBe(0);
+    });
+  });
+
+  describe('amountOfStages correctness', () => {
+    const s0 = new Stage(
+      makeStageData({ stageName: 'A', stageOrder: 0, needsConfirmation: true }),
+    );
+    const s1 = new Stage(makeStageData({ stageName: 'B', stageOrder: 1 }));
+    const s2 = new Stage(makeStageData({ stageName: 'C', stageOrder: 2 }));
+
+    it('is correct', () => {
+      const agg3 = new StagesAggregate([s0, s1, s2]);
+      expect(agg3.amountOfStages).toBe(3);
+    });
+  });
+
+  describe('Stage validation (class-validator)', () => {
+    it('Stage constructor enforces UUIDs and non-empty strings', () => {
+      // bad UUIDs
+      expect(
+        () =>
+          new Stage(
+            makeStageData({
+              orderId: 'nope' as any,
+              workshopId: 'also-bad' as any,
+            }),
+          ),
+      ).toThrow();
+
+      // empty required strings
+      expect(
+        () =>
+          new Stage(
+            makeStageData({
+              stageName: '' as any,
+              description: '' as any,
+              approximateLength: '' as any,
+            }),
+          ),
+      ).toThrow();
+
+      // wrong boolean type
+      expect(
+        () =>
+          new Stage(
+            makeStageData({
+              needsConfirmation: 'yes' as any,
+            }),
+          ),
+      ).toThrow();
+    });
+  });
+});

--- a/apps/order-service/src/app/order-workflow/domain/entities/stage/stage.entity.ts
+++ b/apps/order-service/src/app/order-workflow/domain/entities/stage/stage.entity.ts
@@ -1,0 +1,333 @@
+import {
+  Entity,
+  PrimaryColumn,
+  Column,
+  ManyToOne,
+  JoinColumn,
+  Unique,
+  Index,
+  Check,
+  UpdateDateColumn,
+  VersionColumn,
+  CreateDateColumn,
+} from 'typeorm';
+import {
+  IsUUID,
+  IsString,
+  IsNotEmpty,
+  IsBoolean,
+  Length,
+  IsNumber,
+  Min,
+  IsEnum,
+  IsInt,
+  IsOptional,
+} from 'class-validator';
+import { WorkshopInvitation } from '../workshop-invitation/workshop-invitation.entity';
+import {
+  EntityTechnicalsInterface,
+  IsoDateTransformer,
+} from 'persistence';
+import { assertValid } from 'shared-kernel';
+import { StageStatus } from 'apps/order-service/src/app/order-workflow/domain/entities/stage/stage-status.enum';
+import { DomainError } from 'error-handling/error-core';
+import { OrderDomainErrorRegistry } from 'error-handling/registries/order';
+
+
+/**
+ * Aggregate root for Stage entity.
+ * 
+ */
+export class StagesAggregate {
+  stages: Stage[] = [];
+  
+  amountOfStages = 0;
+
+  /**
+   * Pointer into 0-base array of stages. 
+   * If [lastIndex + 1], that indicates all stages are finished.
+   */
+  currentStage = 0;
+
+
+  constructor(init: Array<Stage | constructStageData>) {
+    // normalize inputs to Stage instances
+    const nameSet = new Set<string>();
+
+    for (const item of init) {
+      const s = this.isStageInstance(item) ? item : new Stage(item);
+
+      if (this.stages[s.stageOrder] !== undefined) {
+        throw new DomainError({
+          errorObject: OrderDomainErrorRegistry.byCode.VALIDATION,
+          details: {
+            description: `duplicate stage_order at index ${s.stageOrder}`,
+          },
+        });
+      }
+      if (nameSet.has(s.stageName)) {
+        throw new DomainError({
+          errorObject: OrderDomainErrorRegistry.byCode.VALIDATION,
+          details: { description: `duplicate stage_name "${s.stageName}"` },
+        });
+      }
+
+      this.stages[s.stageOrder] = s;
+      nameSet.add(s.stageName);
+    }
+
+    // Ensure no holes: stageOrder must be 0..N-1 contiguous
+    // length is highestIndex+1 for arrays; iterate and ensure all defined
+    this.amountOfStages = this.stages.length;
+    for (let i = 0; i < this.amountOfStages; i++) {
+      if (!this.stages[i]) {
+        throw new DomainError({
+          errorObject: OrderDomainErrorRegistry.byCode.VALIDATION,
+          details: { description: `stage missing at order ${i}` },
+        });
+      }
+    }
+
+    // Compute first pending index; if none, set to amountOfStages
+    this.currentStage = this.findFirstNonCompleted() ?? this.amountOfStages;
+  }
+
+  acceptCompletionMarked(data: { stageName: string }): {
+    allCompleted: boolean;
+    stageCompleted: boolean;
+  } {
+    const stage = this.getStageByName(data.stageName);
+
+    if (stage.stageOrder !== this.currentStage) {
+      throw new DomainError({
+        errorObject: OrderDomainErrorRegistry.byCode.INVARIANTS_VIOLATED,
+        details: {
+          description: `Incorrect completionMarked order, current stage is ${this.stages[this.currentStage].stageName}`,
+        },
+      });
+    }
+
+    const newStatus: StageStatus = stage.acceptCompletionMarked();
+
+    // Advance current pointer if we just completed the current stage
+    this.advanceCurrentIfCompleted(stage.stageOrder);
+
+    const stageCompleted: boolean = newStatus === StageStatus.Completed;
+    const allCompleted = this.currentStage === this.amountOfStages;
+    return { allCompleted, stageCompleted };
+  }
+
+  confirmStage(data: { stageName: string }): {
+    allCompleted: boolean;
+  } {
+    const stage = this.getStageByName(data.stageName);
+
+    if (stage.stageOrder !== this.currentStage) {
+      throw new DomainError({
+        errorObject: OrderDomainErrorRegistry.byCode.INVARIANTS_VIOLATED,
+        details: {
+          description: `Incorrect completionMarked order, current stage is ${this.stages[this.currentStage].stageName}`,
+        },
+      });
+    }
+
+    stage.confirmStage();
+
+    this.advanceCurrentIfCompleted(stage.stageOrder);
+
+    const allCompleted = this.currentStage === this.amountOfStages;
+    return { allCompleted };
+  }
+
+  // TODO: change fields of a stage by name or order,
+
+  editStage() {}
+
+
+  private isStageInstance(value: unknown): value is Stage {
+    return value instanceof Stage;
+  }
+
+  private getStageByName(stageName: string): Stage {
+    const s = this.stages.find((st) => st.stageName === stageName);
+    if (!s) {
+      throw new DomainError({
+        errorObject: OrderDomainErrorRegistry.byCode.NOT_FOUND,
+        details: { description: `Stage ${stageName} does not exist` },
+      });
+    }
+    return s;
+  }
+
+  /**
+   * @returns the index of last completed stage, or undefined if all completed
+   */
+  private findFirstNonCompleted(): number | undefined {
+    for (let i = 0; i < this.amountOfStages; i++) {
+      if (this.stages[i]!.status !== StageStatus.Completed) return i;
+    }
+    return undefined;
+  }
+
+  /**
+   * If the current stage got completed, recalculate the current stage by finding first non-completed
+   * @param changedOrder
+   */
+  private advanceCurrentIfCompleted(changedOrder: number): void {
+    if (
+      changedOrder === this.currentStage &&
+      this.stages[changedOrder]!.status === StageStatus.Completed
+    ) {
+      //technically, would work even if StageStatus = awaitingConfiramtion
+      const next = this.findFirstNonCompleted();
+      this.currentStage = next ?? this.amountOfStages;
+    }
+  }
+}
+
+/**
+ * Stage instance. Is a subentity of StagesAggregate - do not interract with it directly.
+ * 
+ */
+@Unique('uq_stage_order_index', ['orderId', 'workshopId', 'stageOrder'])
+@Index('ix_stage_lookup', ['orderId', 'workshopId', 'stageOrder'])
+@Check('chk_stage_order_nonneg', `"stage_order" >= 0`)
+@Entity({ name: 'stage' })
+export class Stage implements EntityTechnicalsInterface {
+  @IsUUID()
+  @PrimaryColumn('uuid', { name: 'order_id' })
+  orderId!: string;
+
+  @IsUUID()
+  @PrimaryColumn('uuid', { name: 'workshop_id' })
+  workshopId!: string;
+
+  @IsString()
+  @IsNotEmpty()
+  @Length(1, 120)
+  @PrimaryColumn('varchar', { name: 'stage_name', length: 120 })
+  stageName!: string;
+
+  @ManyToOne(() => WorkshopInvitation, (o) => o.stages, {
+    onDelete: 'CASCADE',
+    eager: false,
+  })
+  @JoinColumn([
+    { name: 'order_id', referencedColumnName: 'orderId' },
+    { name: 'workshop_id', referencedColumnName: 'workshopId' },
+  ])
+  workshopInvitation!: WorkshopInvitation;
+
+  @IsString()
+  @IsNotEmpty()
+  @Length(1, 64)
+  @Column('varchar', { name: 'approximate_length', length: 64 })
+  approximateLength!: string;
+
+  @IsBoolean()
+  @Column('boolean', { name: 'needs_confirmation', default: false })
+  needsConfirmation!: boolean;
+
+  @IsString()
+  @IsNotEmpty()
+  @Column('text', { name: 'description' })
+  description!: string;
+
+  @IsEnum(StageStatus)
+  @IsString()
+  @IsNotEmpty()
+  @Length(1, 32)
+  @Column({
+    name: 'status',
+    type: 'enum',
+    enum: StageStatus,
+    enumName: 'stage_status',
+  })
+  status!: StageStatus;
+
+  /**
+   * First value - zero
+   */
+  @IsNumber()
+  @Min(0)
+  @Column('integer', { name: 'stage_order' })
+  stageOrder!: number;
+
+  @IsOptional()
+  //@IsISO8601()
+  @UpdateDateColumn({
+    name: 'last_updated_at',
+    type: 'timestamptz',
+    transformer: IsoDateTransformer,
+  })
+  lastUpdatedAt!: string;
+
+  @IsOptional()
+  //@IsISO8601()
+  @CreateDateColumn({
+    name: 'created_at',
+    type: 'timestamptz',
+    transformer: IsoDateTransformer,
+  })
+  createdAt!: string;
+
+  @IsOptional()
+  @IsInt()
+  @VersionColumn({ name: 'version', type: 'int' })
+  version!: number;
+
+  constructor(init: constructStageData) {
+    // typeorm fix
+    if (!init) return;
+
+    this.orderId = init.orderId;
+    this.workshopId = init.workshopId;
+    this.stageName = init.stageName;
+    this.approximateLength = init.approximateLength;
+    this.needsConfirmation = init.needsConfirmation ?? false;
+    this.description = init.description;
+    this.stageOrder = init.stageOrder;
+    this.status = StageStatus.Pending;
+
+    assertValid(this, OrderDomainErrorRegistry); // runs class-validator decorators
+  }
+
+  acceptCompletionMarked(): StageStatus {
+    this.assertStatusIs(StageStatus.Pending);
+
+    this.status = this.needsConfirmation
+      ? StageStatus.AwaitingConfirmation
+      : StageStatus.Completed;
+    return this.status;
+  }
+
+  confirmStage() {
+    this.assertStatusIs(StageStatus.AwaitingConfirmation);
+    this.status = StageStatus.Completed;
+  }
+
+  editStage() {}
+
+  private assertStatusIs<s extends StageStatus>(
+    status: s,
+  ): asserts status is s {
+    if (this.status !== status) {
+      throw new DomainError({
+        errorObject: OrderDomainErrorRegistry.byCode.ILLEGAL_TRANSITION,
+        details: {
+          description: `Stage status mismatch: expected ${status}, is ${this.status}`,
+        },
+      });
+    }
+  }
+}
+
+export type constructStageData = {
+  orderId: string;
+  workshopId: string;
+  stageName: string;
+  approximateLength: string;
+  needsConfirmation: boolean;
+  description: string;
+  stageOrder: number;
+};

--- a/apps/order-service/src/app/order-workflow/domain/entities/workshop-invitation/workshop-invitation.entity.spec.ts
+++ b/apps/order-service/src/app/order-workflow/domain/entities/workshop-invitation/workshop-invitation.entity.spec.ts
@@ -1,0 +1,279 @@
+// apps/order-service/modules/order-workflow/domain/__tests__/workshopInvitation.entity.spec.ts
+
+import { WorkshopInvitation } from 'apps/order-service/src/app/order-workflow/domain/entities/workshop-invitation/workshop-invitation.entity';
+import { WorkshopInvitationStatus } from 'apps/order-service/src/app/order-workflow/domain/entities/workshop-invitation/workshop-invitation.enum';
+import 'reflect-metadata';
+
+describe('WorkshopInvitation (domain entity)', () => {
+  // ---------------- helpers ----------------
+  const uuid = (n = 1) =>
+    `${n.toString().padStart(8, '0')}-1111-4111-8111-11111111111${n}`;
+
+  const makeWorkshopInvitation = (seed?: Partial<WorkshopInvitation>) => {
+    // Bypass constructor so we can control initial shape precisely.
+    const o = Object.create(WorkshopInvitation.prototype) as WorkshopInvitation;
+    o.orderId = seed?.orderId ?? uuid(1);
+    o.workshopId = seed?.workshopId ?? uuid(2);
+    o.status = seed?.status ?? WorkshopInvitationStatus.Pending;
+    o.createdAt = seed?.createdAt ?? new Date().toISOString();
+    // Some codebases call this lastEditedAt in the entity;
+    // keep test-scoped property name consistent with current domain model.
+    (o as any).lastUpdatedAt = (seed as any)?.lastUpdatedAt ?? o.createdAt;
+    o.version = 1;
+    // optional fields left undefined until accept/edit fills them
+    return o;
+  };
+
+  // ---------------- constructor ----------------
+  describe('constructor', () => {
+    it('sets defaults (Pending status)', () => {
+      const o = new WorkshopInvitation({
+        orderId: uuid(1),
+        workshopId: uuid(2),
+      });
+      expect(o.orderId).toBe(uuid(1));
+      expect(o.workshopId).toBe(uuid(2));
+      expect(o.status).toBe(WorkshopInvitationStatus.Pending);
+      // If entity uses lastEditedAt internally, align your constructor to set lastUpdatedAt too.
+    });
+
+    it('throws if IDs are not UUIDs', () => {
+      expect(
+        () => new WorkshopInvitation({ orderId: '123', workshopId: uuid(2) }),
+      ).toThrow();
+      expect(
+        () => new WorkshopInvitation({ orderId: uuid(2), workshopId: '123' }),
+      ).toThrow();
+    });
+  });
+
+  // ---------------- accept ----------------
+  describe('accept', () => {
+    it('from Pending populates details and moves to Accepted', () => {
+      const o = makeWorkshopInvitation({
+        status: WorkshopInvitationStatus.Pending,
+      });
+      const payload = {
+        description: 'Laser engraving and varnish',
+        deadline: new Date(Date.now() + 86400000).toISOString(),
+        budget: '120.00 USD',
+      };
+
+      o.accept(payload);
+
+      expect(o.status).toBe(WorkshopInvitationStatus.Accepted);
+      expect(o.description).toBe(payload.description);
+      expect(o.deadline).toBe(payload.deadline);
+      expect(o.budget).toBe(payload.budget);
+    });
+
+    it('throws if not in Pending', () => {
+      const accepted = makeWorkshopInvitation({
+        status: WorkshopInvitationStatus.Accepted,
+      });
+      const declined = makeWorkshopInvitation({
+        status: WorkshopInvitationStatus.Declined,
+      });
+
+      expect(() =>
+        accepted.accept({
+          description: 'x',
+          deadline: new Date().toISOString(),
+          budget: '1',
+        }),
+      ).toThrow();
+
+      expect(() =>
+        declined.accept({
+          description: 'x',
+          deadline: new Date().toISOString(),
+          budget: '1',
+        }),
+      ).toThrow();
+    });
+
+    // validation-breaking scenarios (rely on assertValid + decorators)
+    it('rejects empty description', () => {
+      const o = makeWorkshopInvitation({
+        status: WorkshopInvitationStatus.Pending,
+      });
+      expect(() =>
+        o.accept({
+          description: '',
+          deadline: new Date(Date.now() + 60000).toISOString(),
+          budget: '100',
+        }),
+      ).toThrow();
+    });
+
+    // it('rejects non-ISO deadline', () => {
+    //   const o = makeWorkshopInvitation({
+    //     status: WorkshopInvitationStatus.Pending,
+    //   });
+    //   expect(() =>
+    //     o.accept({ description: 'ok', deadline: 'not-a-date', budget: '100' }),
+    //   ).toThrow();
+    // });
+
+    it('rejects empty budget', () => {
+      const o = makeWorkshopInvitation({
+        status: WorkshopInvitationStatus.Pending,
+      });
+      expect(() =>
+        o.accept({
+          description: 'ok',
+          deadline: new Date(Date.now() + 60000).toISOString(),
+          budget: '',
+        }),
+      ).toThrow();
+    });
+
+    it('rejects wrong budget type (non-string)', () => {
+      const o = makeWorkshopInvitation({
+        status: WorkshopInvitationStatus.Pending,
+      });
+      
+      expect(() =>
+        o.accept({
+          description: 'ok',
+          deadline: new Date().toISOString(),
+          // @ts-expect-error intentionally wrong type for test
+          budget: 123,
+        }),
+      ).toThrow();
+    });
+
+    it('rejects payload with missing fields', () => {
+      const o = makeWorkshopInvitation({
+        status: WorkshopInvitationStatus.Pending,
+      });
+      // @ts-expect-error intentionally incomplete
+      expect(() => o.accept({ description: 'only-desc' })).toThrow();
+    });
+  });
+
+  // ---------------- decline ----------------
+  describe('decline', () => {
+    it('from Pending moves to Declined', () => {
+      const o = makeWorkshopInvitation({
+        status: WorkshopInvitationStatus.Pending,
+      });
+      o.decline();
+      expect(o.status).toBe(WorkshopInvitationStatus.Declined);
+    });
+
+    it('throws if not in Pending', () => {
+      const o = makeWorkshopInvitation({
+        status: WorkshopInvitationStatus.Accepted,
+      });
+      expect(() => o.decline()).toThrow();
+    });
+  });
+
+  // ---------------- editBudget ----------------
+  describe('editBudget', () => {
+    it('allowed when Accepted', () => {
+      const o = makeWorkshopInvitation({
+        status: WorkshopInvitationStatus.Accepted,
+      });
+      o.budget = '100';
+      o.editBudget('150');
+      expect(o.budget).toBe('150');
+    });
+
+    it('throws when not Accepted', () => {
+      const p = makeWorkshopInvitation({
+        status: WorkshopInvitationStatus.Pending,
+      });
+      expect(() => p.editBudget('200')).toThrow();
+    });
+
+    it('rejects empty budget', () => {
+      const o = makeWorkshopInvitation({
+        status: WorkshopInvitationStatus.Accepted,
+      });
+      o.budget = '100';
+      expect(() => o.editBudget('')).toThrow();
+    });
+
+    it('rejects non-string budget', () => {
+      const o = makeWorkshopInvitation({
+        status: WorkshopInvitationStatus.Accepted,
+      });
+      // @ts-expect-error wrong type on purpose
+      expect(() => o.editBudget(123)).toThrow();
+    });
+  });
+
+  // ---------------- editDescription ----------------
+  describe('editDescription', () => {
+    it('allowed when Accepted', () => {
+      const o = makeWorkshopInvitation({
+        status: WorkshopInvitationStatus.Accepted,
+      });
+      o.description = 'old';
+      o.editDescription('new desc');
+      expect(o.description).toBe('new desc');
+    });
+
+    it('throws when not Accepted', () => {
+      const p = makeWorkshopInvitation({
+        status: WorkshopInvitationStatus.Pending,
+      });
+      expect(() => p.editDescription('nope')).toThrow();
+    });
+
+    it('rejects empty description', () => {
+      const o = makeWorkshopInvitation({
+        status: WorkshopInvitationStatus.Accepted,
+      });
+      o.description = 'old';
+      expect(() => o.editDescription('')).toThrow();
+    });
+
+    it('rejects non-string description', () => {
+      const o = makeWorkshopInvitation({
+        status: WorkshopInvitationStatus.Accepted,
+      });
+      // @ts-expect-error wrong type on purpose
+      expect(() => o.editDescription(42)).toThrow();
+    });
+  });
+
+  // ---------------- editDeadline ----------------
+  describe('editDeadline', () => {
+    it('allowed when Accepted', () => {
+      const o = makeWorkshopInvitation({
+        status: WorkshopInvitationStatus.Accepted,
+      });
+      const nextWeek = new Date(Date.now() + 7 * 86400000).toISOString();
+      o.deadline = new Date().toISOString();
+      o.editDeadline(nextWeek);
+      expect(o.deadline).toBe(nextWeek);
+    });
+
+    it('throws when not Accepted', () => {
+      const p = makeWorkshopInvitation({
+        status: WorkshopInvitationStatus.Pending,
+      });
+      const nextWeek = new Date(Date.now() + 7 * 86400000).toISOString();
+      expect(() => p.editDeadline(nextWeek)).toThrow();
+    });
+
+    // it('rejects non-ISO deadline', () => {
+    //   const o = makeWorkshopInvitation({
+    //     status: WorkshopInvitationStatus.Accepted,
+    //   });
+    //   o.deadline = new Date().toISOString();
+    //   expect(() => o.editDeadline('not-a-date')).toThrow();
+    // });
+
+    it('rejects empty deadline', () => {
+      const o = makeWorkshopInvitation({
+        status: WorkshopInvitationStatus.Accepted,
+      });
+      o.deadline = new Date().toISOString();
+      expect(() => o.editDeadline('')).toThrow();
+    });
+  });
+});

--- a/apps/order-service/src/app/order-workflow/domain/entities/workshop-invitation/workshop-invitation.entity.ts
+++ b/apps/order-service/src/app/order-workflow/domain/entities/workshop-invitation/workshop-invitation.entity.ts
@@ -1,0 +1,250 @@
+import { RequestEntity } from 'apps/order-service/src/app/order-workflow/domain/entities/request/request.entity';
+import { Stage } from 'apps/order-service/src/app/order-workflow/domain/entities/stage/stage.entity';
+import { WorkshopInvitationStatus } from 'apps/order-service/src/app/order-workflow/domain/entities/workshop-invitation/workshop-invitation.enum';
+import {
+  IsUUID,
+  ValidateIf,
+  IsString,
+  IsNotEmpty,
+  IsISO8601,
+  IsEnum,
+  Length,
+  IsOptional,
+  IsInt,
+  IsDate,
+} from 'class-validator';
+import {
+  EntityTechnicalsInterface,
+  IsoDateTransformer,
+} from 'persistence';
+import {
+  Check,
+  Index,
+  Entity,
+  PrimaryColumn,
+  ManyToOne,
+  JoinColumn,
+  Column,
+  UpdateDateColumn,
+  CreateDateColumn,
+  VersionColumn,
+  OneToMany,
+} from 'typeorm';
+import { assertValid } from 'shared-kernel';
+import { DomainError } from 'error-handling/error-core';
+import { OrderDomainErrorRegistry } from 'error-handling/registries/order';
+
+//  - pending|declined -> description, deadline, budget are NULL
+@Check(
+  'chk_workshopInvitation_payload_by_status',
+  `
+  (
+    "status" = '${WorkshopInvitationStatus.Accepted}'
+    AND description IS NOT NULL
+    AND deadline IS NOT NULL
+    AND budget IS NOT NULL
+  )
+  OR
+  (
+    "status" IN ('${WorkshopInvitationStatus.Pending}', '${WorkshopInvitationStatus.Declined}')
+    AND description IS NULL
+    AND deadline IS NULL
+    AND budget IS NULL
+  )
+  `,
+)
+@Index('ix_workshopInvitation_order_status', ['orderId', 'status'])
+@Index('ix_workshopInvitation_workshop', ['workshopId'])
+@Entity({ name: 'workshopInvitation' })
+export class WorkshopInvitation implements EntityTechnicalsInterface {
+  // composite PK: one workshopInvitation per (order, workshop)
+  @IsUUID(4, {
+    groups: [
+      WorkshopInvitationStatus.Pending,
+      WorkshopInvitationStatus.Declined,
+      WorkshopInvitationStatus.Accepted,
+    ],
+  })
+  @PrimaryColumn('uuid', { name: 'order_id' })
+  orderId!: string;
+
+  @IsUUID(4, {
+    groups: [
+      WorkshopInvitationStatus.Pending,
+      WorkshopInvitationStatus.Declined,
+      WorkshopInvitationStatus.Accepted,
+    ],
+  })
+  @PrimaryColumn('uuid', { name: 'workshop_id' })
+  workshopId!: string;
+
+  @ManyToOne(() => RequestEntity, { onDelete: 'CASCADE', eager: false })
+  @JoinColumn({ name: 'order_id', referencedColumnName: 'orderId' })
+  request!: RequestEntity;
+
+  // These are nullable in DB because "pending/declined" must not carry payload.
+  // Validators require them only for 'accepted'.
+  @ValidateIf((o) => o.status === WorkshopInvitationStatus.Accepted)
+  @IsString({ groups: [WorkshopInvitationStatus.Accepted, 'description'] })
+  @IsNotEmpty({ groups: [WorkshopInvitationStatus.Accepted, 'description'] })
+  @Column('text', { name: 'description', nullable: true })
+  description!: string | null;
+
+  @ValidateIf((o) => o.status === WorkshopInvitationStatus.Accepted)
+  //@IsISO8601({}, { groups: [WorkshopInvitationStatus.Accepted, 'deadline'] })
+  @IsNotEmpty({ groups: [WorkshopInvitationStatus.Accepted, 'deadline'] })
+  @Column({
+    name: 'deadline',
+    type: 'timestamptz',
+    transformer: IsoDateTransformer,
+    nullable: true,
+  })
+  deadline!: string | null;
+
+  @ValidateIf((o) => o.status === WorkshopInvitationStatus.Accepted)
+  @IsString({ groups: [WorkshopInvitationStatus.Accepted, 'budget'] })
+  @IsNotEmpty({ groups: [WorkshopInvitationStatus.Accepted, 'budget'] })
+  @Column('varchar', { name: 'budget', length: 64, nullable: true })
+  budget!: string | null;
+
+  @IsEnum(WorkshopInvitationStatus, {
+    groups: [
+      WorkshopInvitationStatus.Pending,
+      WorkshopInvitationStatus.Accepted,
+      'status',
+      WorkshopInvitationStatus.Declined,
+    ],
+  })
+  @Length(1, 32, {
+    groups: [
+      WorkshopInvitationStatus.Pending,
+      WorkshopInvitationStatus.Accepted,
+      'status',
+      WorkshopInvitationStatus.Declined,
+    ],
+  })
+  @Column({
+    name: 'status',
+    type: 'enum',
+    enum: WorkshopInvitationStatus,
+    enumName: 'workshopInvitation_status',
+  })
+  status!: WorkshopInvitationStatus;
+
+  @IsOptional()
+  //@IsISO8601()
+  @UpdateDateColumn({
+    name: 'last_updated_at',
+    type: 'timestamptz',
+    transformer: IsoDateTransformer,
+  })
+  lastUpdatedAt!: string;
+
+  @IsOptional()
+  //@IsISO8601()
+  @CreateDateColumn({
+    name: 'created_at',
+    type: 'timestamptz',
+    transformer: IsoDateTransformer,
+  })
+  createdAt!: string;
+
+  @IsOptional()
+  @IsInt()
+  @VersionColumn({ name: 'version', type: 'int' })
+  version!: number;
+
+  @OneToMany(() => Stage, (s) => s.workshopInvitation, {
+    cascade: true,
+    eager: false,
+  })
+  stages!: Stage[];
+
+  constructor(init: { orderId: string; workshopId: string }) {
+    // typeorm fix
+    if (!init) return;
+
+    this.orderId = init.orderId;
+    this.workshopId = init.workshopId;
+    this.status = WorkshopInvitationStatus.Pending;
+
+    //this.placedAt = isoNow();
+    //this.lastUpdatedAt = this.placedAt
+    assertValid(this, OrderDomainErrorRegistry);
+  }
+
+  accept(data: { description: string; deadline: string; budget: string }) {
+    this.assertWorkshopInvitationStatusIs(WorkshopInvitationStatus.Pending);
+
+    const o = Object.create(WorkshopInvitation.prototype) as WorkshopInvitation;
+    Object.assign(o, this);
+
+    o.deadline = data.deadline;
+    o.description = data.description;
+    o.budget = data.budget;
+    o.status = WorkshopInvitationStatus.Accepted;
+
+    assertValid(o, OrderDomainErrorRegistry);
+
+    Object.assign(this, o);
+  }
+
+  decline() {
+    this.assertWorkshopInvitationStatusIs(WorkshopInvitationStatus.Pending);
+
+    this.status = WorkshopInvitationStatus.Declined;
+  }
+
+  editBudget(budget: string) {
+    const oldBudget = this.budget;
+    this.assertWorkshopInvitationStatusIs(WorkshopInvitationStatus.Accepted);
+
+    this.budget = budget;
+
+    try {
+      assertValid(this, OrderDomainErrorRegistry, ['budget']);
+    } catch (error) {
+      this.budget = oldBudget;
+      throw error;
+    }
+  }
+
+  editDescription(description: string) {
+    const oldDescription = this.description;
+    this.assertWorkshopInvitationStatusIs(WorkshopInvitationStatus.Accepted);
+    this.description = description;
+
+    try {
+      assertValid(this,  OrderDomainErrorRegistry, ['description']);
+    } catch (error) {
+      this.description = oldDescription;
+      throw error;
+    }
+  }
+
+  editDeadline(deadline: string) {
+    const oldDeadline = this.deadline;
+    this.assertWorkshopInvitationStatusIs(WorkshopInvitationStatus.Accepted);
+    this.deadline = deadline;
+
+    try {
+      assertValid(this,  OrderDomainErrorRegistry, ['deadline']);
+    } catch (error) {
+      this.deadline = oldDeadline;
+      throw error;
+    }
+  }
+
+  private assertWorkshopInvitationStatusIs<s extends WorkshopInvitationStatus>(
+    status: s,
+  ): asserts status is s {
+    if (!(this.status === status)) {
+      throw new DomainError({
+        errorObject: OrderDomainErrorRegistry.byCode.ILLEGAL_TRANSITION,
+        details: {
+          description: `Workshop Invitation status mismatch: expected ${status}, is ${this.status}`,
+        },
+      });
+    }
+  }
+}

--- a/apps/order-service/src/app/order-workflow/domain/entities/workshop-invitation/workshop-invitation.enum.ts
+++ b/apps/order-service/src/app/order-workflow/domain/entities/workshop-invitation/workshop-invitation.enum.ts
@@ -1,0 +1,5 @@
+export enum WorkshopInvitationStatus {
+  Pending = 'pending',
+  Accepted = 'accepted',
+  Declined = 'declined',
+}

--- a/libs/shared-kernel/src/lib/domain/assertions/assert-valid-class-validator.assertion.ts
+++ b/libs/shared-kernel/src/lib/domain/assertions/assert-valid-class-validator.assertion.ts
@@ -1,0 +1,46 @@
+import { validateSync } from 'class-validator';
+import { BaseDescriptor, DomainError } from 'error-handling/error-core';
+
+
+
+/**
+ * Method to validate class-validator decorators on instances.
+ * Lives in shared library and have to be explicitly passed the
+ * domain error registry of the service you are in. Assumes the service has
+ * VALIDATION error defined.
+ * 
+ * 
+ * @param instance 
+ * @param errorRegistry domain error registry of the current service.
+ * @param groups Optional decorator groups.
+ */
+export function assertValid<E extends {byCode: {["VALIDATION"]: BaseDescriptor<"VALIDATION">}}>(
+  instance: object,
+  errorRegistry: E,
+  groups: string[] | undefined = undefined,
+): void {
+
+
+  const groupsObject = groups ? { groups: groups } : {};
+  
+  const errors = validateSync(instance as any, {
+    //those are very permissive - throw only iff constraint on the property
+    //violated, does not modify the entity.
+    whitelist: false,
+    forbidNonWhitelisted: false,
+    forbidUnknownValues: false,
+    skipMissingProperties: false,
+    skipUndefinedProperties: false,
+    skipNullProperties: false,
+    validationError: { target: true, value: true }, 
+    ...groupsObject,
+  });
+  if (errors.length) {
+    throw new DomainError({
+      errorObject: errorRegistry.byCode.VALIDATION,
+      cause: {output: `Validation failed: ${JSON.stringify(errors, null, 2)}`}
+    })
+  }
+}
+
+

--- a/libs/shared-kernel/src/lib/domain/constants/time.constant.ts
+++ b/libs/shared-kernel/src/lib/domain/constants/time.constant.ts
@@ -1,0 +1,3 @@
+export const thirtyDaysInSeconds = 30 * 24 * 60 * 60;
+
+export const thirtyDaysInMinutes = 30 * 24 * 60;

--- a/libs/shared-kernel/src/lib/domain/services/enum-from-obj.service.ts
+++ b/libs/shared-kernel/src/lib/domain/services/enum-from-obj.service.ts
@@ -1,0 +1,21 @@
+/**
+ * Turns an object's own string keys into an enum-like object:
+ *   { a: 1, b: 2 } -> { a: 'a', b: 'b' } (frozen)
+ *
+ * Type:
+ *   makeFieldEnum(obj) returns { [K in keyof obj & string]: K }
+ *   so Fields.a is exactly the type 'a', not just string.
+ */
+export type FieldEnum<T extends object> = {
+  readonly [K in Extract<keyof T, string>]: K;
+};
+
+export function makeFieldEnum<T extends object>(obj: T): FieldEnum<T> {
+  const out = Object.create(null) as Record<string, string>;
+  for (const k in obj) {
+    if (Object.prototype.hasOwnProperty.call(obj, k)) {
+      out[k] = k;
+    }
+  }
+  return Object.freeze(out) as FieldEnum<T>;
+}

--- a/libs/shared-kernel/src/lib/domain/services/extract-bool-env.service.ts
+++ b/libs/shared-kernel/src/lib/domain/services/extract-bool-env.service.ts
@@ -1,0 +1,2 @@
+export const extractBoolEnv = (v: any, d = false) =>
+  v == null ? d : `${v}`.toLowerCase() === 'true';

--- a/libs/shared-kernel/src/lib/domain/services/extract-str-env-with-fallback.service.ts
+++ b/libs/shared-kernel/src/lib/domain/services/extract-str-env-with-fallback.service.ts
@@ -1,0 +1,2 @@
+export const extractStrEnvWithFallback = (v: any, d: any) =>
+  v == null || v === '' ? d : v;

--- a/libs/shared-kernel/src/lib/domain/services/iso-now-time.service.ts
+++ b/libs/shared-kernel/src/lib/domain/services/iso-now-time.service.ts
@@ -1,0 +1,1 @@
+export const isoNow = (): string => new Date().toISOString();

--- a/libs/shared-kernel/src/lib/domain/types/get-instance-type.type.ts
+++ b/libs/shared-kernel/src/lib/domain/types/get-instance-type.type.ts
@@ -1,0 +1,3 @@
+export type GetInstanceType<C> = C extends new (...args: any[]) => infer R
+  ? R
+  : never;

--- a/libs/shared-kernel/src/lib/domain/validators/is-date-or-iso-string.validator.ts
+++ b/libs/shared-kernel/src/lib/domain/validators/is-date-or-iso-string.validator.ts
@@ -1,0 +1,19 @@
+// validators/is-date-or-iso-string.ts
+import { ValidateBy, buildMessage } from 'class-validator';
+// class-validator depends on 'validator', so this import works out of the box
+// If your toolchain is ESM, keep the "" suffix; otherwise drop it.
+import isISO8601 from 'validator/lib/isISO8601';
+
+export function IsDateOrIsoString() {
+  return ValidateBy({
+    name: 'isDateOrIsoString',
+    validator: {
+      validate: (v: unknown) =>
+        (v instanceof Date && !Number.isNaN(v.getTime())) ||
+        (typeof v === 'string' && isISO8601(v, { strict: true })),
+      defaultMessage: buildMessage(
+        () => 'must be a Date object or an ISO 8601 string',
+      ),
+    },
+  });
+}


### PR DESCRIPTION
- Implemented the core business logic for those entities.
- Added shared functions into the Shared-kernel lib.
- Defined basic unit-tests.