### PR TITLE
feat: improve logging and error handling

### DIFF
--- a/apps/bonus-service/src/app/modules/bonus-processor/application/services/bonus-event/bonus-event.service.ts
+++ b/apps/bonus-service/src/app/modules/bonus-processor/application/services/bonus-event/bonus-event.service.ts
@@ -1,4 +1,5 @@
-import { HttpStatus, Injectable, Logger } from '@nestjs/common';
+import { Injectable } from '@nestjs/common';
+import { logInfo } from 'observability';
 import { BonusEventProcessCommand } from 'apps/bonus-service/src/app/modules/bonus-processor/application/services/bonus-event/bonus-event.command';
 import { BonusEventEntity } from 'apps/bonus-service/src/app/modules/bonus-processor/domain/aggregates/common/bonus-event.entity';
 import { VipProfile } from 'apps/bonus-service/src/app/modules/bonus-processor/domain/aggregates/vip-profile/vip-profile.entity';
@@ -24,6 +25,19 @@ export class BonusEventService {
     private readonly vipProfileRepo: VipProfileRepo,
   ) {}
   async process(cmd: BonusEventProcessCommand) {
+    logInfo(
+      {
+        msg: 'Processing bonus event',
+        controller: BonusEventService.name,
+        method: this.process.name,
+      },
+      {
+        commissionerId: cmd.commissionerId,
+        eventName: cmd.eventName,
+        eventId: cmd.eventId,
+      },
+    );
+
     return this.uow.runWithRetry({}, async () => {
       const event = new BonusEventEntity({
         eventId: cmd.eventId,

--- a/libs/observability/src/index.ts
+++ b/libs/observability/src/index.ts
@@ -3,3 +3,4 @@ export * from './lib/config/winston-config.factory';
 export * from './lib/formatters/otel-trace-log.formatter';
 export * from './lib/formatters/secret-masking.formatter';
 export * from './lib/interceptors/logging.interceptor';
+export * from './lib/wrappers';

--- a/libs/observability/src/lib/wrappers/index.ts
+++ b/libs/observability/src/lib/wrappers/index.ts
@@ -1,0 +1,2 @@
+export * from './log-info';
+export * from './log-error';

--- a/libs/observability/src/lib/wrappers/log-error.ts
+++ b/libs/observability/src/lib/wrappers/log-error.ts
@@ -1,0 +1,27 @@
+import { Logger } from '@nestjs/common';
+import { LogInfoDto } from './log-info';
+
+/**
+ * Error log DTO mirroring the standard AppError shape.
+ */
+export interface ErrorLogDto extends LogInfoDto {
+  error: unknown;
+  kind?: string;
+  service?: string;
+  code?: string;
+  retryable?: boolean;
+  v?: number;
+  details?: unknown;
+}
+
+/**
+ * Emit a structured error log. Additional info may be supplied and will
+ * overwrite existing fields.
+ */
+export function logError(
+  dto: ErrorLogDto,
+  additional: Record<string, unknown> = {},
+  overrides: Record<string, unknown> = {},
+): void {
+  Logger.error({ ...dto, ...additional, ...overrides });
+}

--- a/libs/observability/src/lib/wrappers/log-info.ts
+++ b/libs/observability/src/lib/wrappers/log-info.ts
@@ -1,0 +1,26 @@
+import { Logger } from '@nestjs/common';
+
+/**
+ * Basic shape for operational logs. These fields are optional but hint at
+ * useful data points.
+ */
+export interface LogInfoDto {
+  /** Human readable message */
+  msg: string;
+  controller?: string;
+  method?: string;
+  meta?: Record<string, unknown>;
+  [key: string]: unknown;
+}
+
+/**
+ * Emit a structured log. Additional info may be supplied and will overwrite
+ * existing fields.
+ */
+export function logInfo(
+  dto: LogInfoDto,
+  additional: Record<string, unknown> = {},
+  overrides: Record<string, unknown> = {},
+): void {
+  Logger.log({ ...dto, ...additional, ...overrides });
+}


### PR DESCRIPTION
## Summary
- move log wrappers to reusable `wrappers` module and rename info logger to `logInfo`
- adjust logging interceptor and kafka error interceptor to use overrides for transport and duration
- add application-layer logging via new wrapper

## Testing
- `npx tsc -p libs/observability/tsconfig.json`
- `npx tsc -p libs/error-handling/interceptor/tsconfig.json`
- `npx tsc -p apps/bonus-service/tsconfig.json`


------
https://chatgpt.com/codex/tasks/task_e_68b4f1279430832e94ebe8a6132eb235