### PR TITLE
test(global): cover aggregate subentities loading

### DIFF
--- a/apps/bonus-service/src/app/modules/bonus-processor/infra/persistence/repositories/additive-bonus/additive-bonus.repo.ts
+++ b/apps/bonus-service/src/app/modules/bonus-processor/infra/persistence/repositories/additive-bonus/additive-bonus.repo.ts
@@ -18,7 +18,10 @@ export class AdditiveBonusRepo {
     try {
       const entity: AdditiveBonus | null = await currentManager(
         this.ds,
-      ).findOne(AdditiveBonus, { where: { commissionerId } });
+      ).findOne(AdditiveBonus, {
+        where: { commissionerId },
+        relations: { events: true },
+      });
       return entity;
     } catch (error) {
       remapTypeOrmPgErrorToInfra(error);

--- a/apps/bonus-service/src/app/modules/bonus-processor/infra/persistence/repositories/vip-profile/vip-profile.repo.ts
+++ b/apps/bonus-service/src/app/modules/bonus-processor/infra/persistence/repositories/vip-profile/vip-profile.repo.ts
@@ -20,7 +20,7 @@ export class VipProfileRepo {
     try {
       const entity: VipProfile | null = await currentManager(this.ds).findOne(
         VipProfile,
-        { where: { commissionerId } },
+        { where: { commissionerId }, relations: { lastMonthEvents: true } },
       );
       return entity;
     } catch (error) {

--- a/apps/order-service/src/app/order-workflow/infra/persistence/repositories/request/request.repo.ts
+++ b/apps/order-service/src/app/order-workflow/infra/persistence/repositories/request/request.repo.ts
@@ -14,7 +14,10 @@ export class RequestRepo {
   ): Promise<RequestEntity | null> {
     const manager = requireTxManager(this.ds);
     try {
-      const row = await manager.findOne(RequestEntity, { where: { orderId } });
+      const row = await manager.findOne(RequestEntity, {
+        where: { orderId },
+        relations: { workshopInvitations: true },
+      });
       return row;
     } catch (error) {
       remapTypeOrmPgErrorToInfra(error);


### PR DESCRIPTION
## Summary
- eager load VipProfile lastMonthEvents and AdditiveBonus events in repos
- load Request workshop invitations with findById
- add integration tests asserting subentity loading
