### PR TITLE
refactor(global): apply interceptors per endpoint

### DIFF
--- a/apps/bonus-service/src/app/modules/bonus-processor/adapters/inbound/messaging/kafka.consumer.ts
+++ b/apps/bonus-service/src/app/modules/bonus-processor/adapters/inbound/messaging/kafka.consumer.ts
@@ -14,12 +14,13 @@ import { ProgrammerErrorRegistry } from 'error-handling/registries/common';
 import { isoNow } from 'shared-kernel';
 import { ProgrammerError } from 'error-handling/error-core';
 import { KafkaErrorInterceptor } from 'error-handling/interceptor';
+import { LoggingInterceptor } from 'observability';
 
+@UseInterceptors(KafkaErrorInterceptor, LoggingInterceptor)
 @Controller()
 export class BonusEventsConsumer {
   constructor(private readonly bonusService: BonusEventService) {}
 
-  @UseInterceptors(KafkaErrorInterceptor)
   @EventPattern(KafkaTopics.OrderTransitions)
   async onOrderTransitions(
     @Payload() payload: unknown,

--- a/apps/bonus-service/src/app/modules/read-projection/adapters/inbound/http/bonus-read.controller.ts
+++ b/apps/bonus-service/src/app/modules/read-projection/adapters/inbound/http/bonus-read.controller.ts
@@ -6,6 +6,7 @@ import {
   Query,
   UsePipes,
   ValidationPipe,
+  UseInterceptors,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -14,12 +15,15 @@ import {
   ApiAcceptedResponse,
 } from '@nestjs/swagger';
 import { BonusReadHandler } from 'apps/bonus-service/src/app/modules/read-projection/application/bonus-read/bonus-read.query-handler';
+import { HttpErrorInterceptor } from 'error-handling/interceptor';
+import { LoggingInterceptor } from 'observability';
 import {
   BonusReadresultDto,
   BonusReadQueryDto,
 } from 'contracts';
 
 @ApiTags('Bonus read')
+@UseInterceptors(HttpErrorInterceptor, LoggingInterceptor)
 @Controller('bonus-read')
 export class BonusReadController {
   constructor(private readonly svc: BonusReadHandler) {}

--- a/apps/order-service/src/app/order-workflow/adapters/inbound/http/order-init.controller.ts
+++ b/apps/order-service/src/app/order-workflow/adapters/inbound/http/order-init.controller.ts
@@ -3,6 +3,7 @@ import {
   Controller,
   Post,
   HttpCode,
+  UseInterceptors,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -12,10 +13,13 @@ import {
   ApiBadRequestResponse,
 } from '@nestjs/swagger';
 import { OrderInitService } from 'apps/order-service/src/app/order-workflow/application/services/order/order-init.service';
+import { HttpErrorInterceptor } from 'error-handling/interceptor';
+import { LoggingInterceptor } from 'observability';
   // Re-exported DTO from libs/contracts
 import { OrderInitDtoV1 } from 'contracts';
 
 @ApiTags('Order workflow')
+@UseInterceptors(HttpErrorInterceptor, LoggingInterceptor)
 @Controller({ path: 'order', version: '1' })
 export class OrderInitController {
   constructor(private readonly orderInitService: OrderInitService) {}

--- a/apps/order-service/src/app/order-workflow/adapters/inbound/http/stage-completion.controller.ts
+++ b/apps/order-service/src/app/order-workflow/adapters/inbound/http/stage-completion.controller.ts
@@ -2,6 +2,7 @@ import {
   Body,
   Controller,
   Post,
+  UseInterceptors,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -11,12 +12,15 @@ import {
   ApiBadRequestResponse,
 } from '@nestjs/swagger';
 import { StageCompletionService } from 'apps/order-service/src/app/order-workflow/application/services/stage/stage-completion.service';
+import { HttpErrorInterceptor } from 'error-handling/interceptor';
+import { LoggingInterceptor } from 'observability';
 import {
   MarkStageCompletionDtoV1,
   ConfirmStageCompletionDtoV1,
 } from 'contracts';
 
 @ApiTags('Order workflow')
+@UseInterceptors(HttpErrorInterceptor, LoggingInterceptor)
 @Controller({ path: 'stage-completion', version: '1' })
 export class StageCompletionController {
   constructor(

--- a/apps/order-service/src/app/order-workflow/adapters/inbound/http/workshop-invitation-response.controller.ts
+++ b/apps/order-service/src/app/order-workflow/adapters/inbound/http/workshop-invitation-response.controller.ts
@@ -2,6 +2,7 @@ import {
   Body,
   Controller,
   Post,
+  UseInterceptors,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -11,12 +12,15 @@ import {
   ApiBadRequestResponse,
 } from '@nestjs/swagger';
 import { WorkshopInvitationResponseService } from 'apps/order-service/src/app/order-workflow/application/services/workshop/workshop-invitation-response.service';
+import { HttpErrorInterceptor } from 'error-handling/interceptor';
+import { LoggingInterceptor } from 'observability';
 import {
   AcceptWorkshopInvitationDtoV1,
   DeclineWorkshopInvitationDtoV1,
 } from 'contracts';
 
 @ApiTags('Order workflow')
+@UseInterceptors(HttpErrorInterceptor, LoggingInterceptor)
 @Controller({ path: 'workshop-invitaion', version: '1' })
 export class WorkshopInvitationResponseController {
   constructor(

--- a/apps/order-service/src/app/read-model/adapters/http/order-history.controller.ts
+++ b/apps/order-service/src/app/read-model/adapters/http/order-history.controller.ts
@@ -6,6 +6,7 @@ import {
   Query,
   UsePipes,
   ValidationPipe,
+  UseInterceptors,
 } from '@nestjs/common';
 import {
   ApiTags,
@@ -15,12 +16,15 @@ import {
   ApiAcceptedResponse,
 } from '@nestjs/swagger';
 import { OrderStagesReadService } from 'apps/order-service/src/app/read-model/application/query-handlers/history.query-handler';
+import { HttpErrorInterceptor } from 'error-handling/interceptor';
+import { LoggingInterceptor } from 'observability';
 import {
   OrderHistoryQueryResultDto,
   ReadOrderStagesQueryDto,
 } from 'contracts';
 
 @ApiTags('Orders read')
+@UseInterceptors(HttpErrorInterceptor, LoggingInterceptor)
 @Controller('orders/stages')
 export class OrderHistoryController {
   constructor(private readonly svc: OrderStagesReadService) {}

--- a/apps/order-service/src/main.ts
+++ b/apps/order-service/src/main.ts
@@ -7,10 +7,6 @@ import { WINSTON_MODULE_NEST_PROVIDER } from 'nest-winston';
 import { OrderWorkflowModule } from 'apps/order-service/src/app/order-workflow/infra/di/order-workflow.module';
 import { orderWorkflowKafkaConfig } from 'apps/order-service/src/app/order-workflow/infra/config/kafka.config';
 import { OrderReadModule } from 'apps/order-service/src/app/read-model/infra/di/order-read.module';
-import { HttpErrorInterceptor, KafkaErrorInterceptor } from 'error-handling/interceptor';
-import { LoggingInterceptor } from 'observability';
-
-
 
 function setupSwagger(app: INestApplication, {
   title,
@@ -25,7 +21,6 @@ function setupSwagger(app: INestApplication, {
   SwaggerModule.setup(path, app, doc, { customSiteTitle: title });
 }
 
-
 async function startOrderWorkflowApp() {
   const httpPort = Number(process.env.ORDER_WRKFLOW_HTTP_PORT ?? 3001);
 
@@ -33,13 +28,6 @@ async function startOrderWorkflowApp() {
   app.useLogger(app.get(WINSTON_MODULE_NEST_PROVIDER));
   app.enableShutdownHooks();
   app.setGlobalPrefix(process.env.HTTP_PREFIX ?? 'api');
-  app.useGlobalInterceptors(
-    app.get(KafkaErrorInterceptor),
-    app.get(HttpErrorInterceptor),
-    app.get(LoggingInterceptor),
-  );
-
-
 
   app.connectMicroservice<MicroserviceOptions>({
     transport: Transport.KAFKA,
@@ -66,35 +54,23 @@ async function startOrderReadApp() {
   app.useLogger(app.get(WINSTON_MODULE_NEST_PROVIDER));
   app.enableShutdownHooks();
   app.setGlobalPrefix(process.env.HTTP_PREFIX ?? 'api');
-  app.useGlobalInterceptors(
-
-    app.get(HttpErrorInterceptor),
-    app.get(LoggingInterceptor),
-  );
-
-
 
   setupSwagger(app, { title: 'Order Read API', path: 'docs', version: '1.0' });
 
   await app.listen(httpPort);
   const url = await app.getUrl();
-
 }
-
 
 async function bootstrap() {
   //await otelSDK.start();
 
-
-
-  await startOrderWorkflowApp()
+  await startOrderWorkflowApp();
   //read assumes entities defined in DB
-  await startOrderReadApp()
+  await startOrderReadApp();
 
   // Graceful shutdown on signals
   const shutdown = async (signal: string) => {
-
-    console.log(`\nReceived ${signal}. Shutting down...`)
+    console.log(`\nReceived ${signal}. Shutting down...`);
     process.exit(0);
   };
   process.on('SIGINT', () => shutdown('SIGINT'));
@@ -106,3 +82,4 @@ bootstrap().catch((err) => {
   console.error('Fatal on bootstrap:', err);
   process.exit(1);
 });
+


### PR DESCRIPTION
## Summary
- remove global interceptor registration from bonus and order services
- use `@UseInterceptors` on HTTP and Kafka handlers
